### PR TITLE
Local settings for ack (ack-grep)

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,8 @@
+--ignore-dir=.idea
+--ignore-dir=.ipynb_checkpoints
+--ignore-dir=.tox
+--ignore-dir=build
+--ignore-dir=Cliche.egg-info
+--ignore-dir=dist
+--ignore-dir=docs/build
+--ignore-dir=htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.cfg.py
+*.cfg.yml
 *.db
 *.db-journal
 *.egg


### PR DESCRIPTION
The title says it all, but for more explanation: `ack` (`ack-grep` in Debian/Ubuntu) is a better alternative to vanilla `grep -r` for programmers.  It ignores binary files, object files, and VCS special directories (e.g. `.git`, `.svn`, `CVS`) by default.  This patch adds some more patterns to ignore.
