### PR TITLE
Correspondence for ontology matching (alignment)

### DIFF
--- a/cliche/migrations/versions/4ff1834aa21_modify_correspondence_tables.py
+++ b/cliche/migrations/versions/4ff1834aa21_modify_correspondence_tables.py
@@ -1,0 +1,70 @@
+"""modify correspondence tables
+
+Revision ID: 4ff1834aa21
+Revises: 26c5e973581
+Create Date: 2014-11-18 21:56:39.319294
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4ff1834aa21'
+down_revision = '26c5e973581'
+
+
+def upgrade():
+    op.create_table(
+        'cliche_tvtropes_edges',
+        sa.Column('cliche_id', sa.Integer(), nullable=False),
+        sa.Column('tvtropes_namespace', sa.String(), nullable=False),
+        sa.Column('tvtropes_name', sa.String(), nullable=False),
+        sa.Column('confidence', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['cliche_id'], ['works.id']),
+        sa.ForeignKeyConstraint(['tvtropes_namespace',
+                                 'tvtropes_name'],
+                                ['tvtropes_entities.namespace',
+                                 'tvtropes_entities.name']),
+        sa.PrimaryKeyConstraint('cliche_id', 'tvtropes_namespace',
+                                'tvtropes_name')
+    )
+    op.create_table(
+        'cliche_wikipedia_edge',
+        sa.Column('cliche_id', sa.Integer(), nullable=False),
+        sa.Column('wikipedia_name', sa.String(), nullable=False),
+        sa.Column('confidence', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['cliche_id'], ['works.id']),
+        sa.ForeignKeyConstraint(['wikipedia_name'],
+                                ['wikipedia_entities.name']),
+        sa.PrimaryKeyConstraint('cliche_id', 'wikipedia_name')
+    )
+    op.drop_table('cli_wiki_corres')
+    op.drop_table('cli_tv_corres')
+
+
+def downgrade():
+    op.create_table(
+        'cli_tv_corres',
+        sa.Column('cli_id', sa.Integer(), nullable=False),
+        sa.Column('tv_namespace', sa.String(), nullable=False),
+        sa.Column('tv_name', sa.String(), nullable=False),
+        sa.Column('confidence', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['cli_id'], ['works.id']),
+        sa.ForeignKeyConstraint(
+            ['tv_namespace', 'tv_name'],
+            ['tvtropes_entities.namespace', 'tvtropes_entities.name']
+        ),
+        sa.PrimaryKeyConstraint('cli_id', 'tv_namespace', 'tv_name')
+    )
+    op.create_table(
+        'cli_wiki_corres',
+        sa.Column('cli_id', sa.Integer(), nullable=False),
+        sa.Column('wiki_name', sa.String(), nullable=False),
+        sa.Column('confidence', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['cli_id'], ['works.id']),
+        sa.ForeignKeyConstraint(['wiki_name'], ['wikipedia_entities.name']),
+        sa.PrimaryKeyConstraint('cli_id', 'wiki_name')
+    )
+    op.drop_table('cliche_wikipedia_edge')
+    op.drop_table('cliche_tvtropes_edges')

--- a/cliche/services/tvtropes/entities.py
+++ b/cliche/services/tvtropes/entities.py
@@ -4,14 +4,16 @@
 .. _TVTropes: http://tvtropes.org/
 
 """
-from sqlalchemy import Column, DateTime, ForeignKeyConstraint, String
 from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Column, ForeignKey, ForeignKeyConstraint
 from sqlalchemy.sql.expression import and_
+from sqlalchemy.types import DateTime, Integer, String
 
 from ...orm import Base
+from ...work import Work
 
 
-__all__ = 'Entity', 'Redirection', 'Relation'
+__all__ = 'ClicheTvtropesEdge', 'Entity', 'Redirection', 'Relation'
 
 
 class Entity(Base):
@@ -39,7 +41,7 @@ class Entity(Base):
                  Entity.name == Redirection.original_name),
         collection_class=set)
 
-    corres = relationship('cliche.work.CliTvCorres', collection_class=set)
+    corres = relationship('ClicheTvtropesEdge', collection_class=set)
 
     __tablename__ = 'tvtropes_entities'
     __repr_columns__ = namespace, name
@@ -89,3 +91,26 @@ class Relation(Base):
     __tablename__ = 'tvtropes_relations'
     __repr_columns__ = (origin_namespace, origin_name, destination_namespace,
                         destination_name)
+
+
+class ClicheTvtropesEdge(Base):
+    """Correspondence between Works of Cliche and TV Tropes"""
+
+    cliche_id = Column(Integer, ForeignKey(Work.id), primary_key=True)
+    cliche_work = relationship(Work)
+    tvtropes_namespace = Column(String, primary_key=True)
+    tvtropes_name = Column(String, primary_key=True)
+    tvtropes_entity = relationship(Entity,
+                                   foreign_keys=[tvtropes_namespace,
+                                                 tvtropes_name])
+    confidence = Column(Integer, default=0.5)
+
+    __tablename__ = 'cliche_tvtropes_edges'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [tvtropes_namespace, tvtropes_name],
+            [Entity.namespace, Entity.name]
+        ),
+    )
+    __repr_columns__ = (cliche_id, tvtropes_namespace, tvtropes_name,
+                        confidence)

--- a/cliche/services/wikipedia/work.py
+++ b/cliche/services/wikipedia/work.py
@@ -8,13 +8,15 @@ All classes in this file are rdfs:domain of its columns.
 """
 from urllib.parse import unquote_plus
 
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from ...orm import Base
+from ...work import Work as ClicheWork
 
 
-__all__ = 'Entity', 'Relation', 'Artist', 'Work', 'Film', 'Book'
+__all__ = ('ClicheWikipediaEdge', 'Entity', 'Relation', 'Artist', 'Work',
+           'Film', 'Book')
 
 
 def url_to_label(url):
@@ -109,7 +111,7 @@ class Work(Entity):
     author = Column(String)
     main_character = Column(String)
     previous_work = Column(String)
-    corres = relationship('cliche.work.CliWikiCorres', collection_class=set)
+    corres = relationship('ClicheWikipediaEdge', collection_class=set)
 
     __mapper_args__ = {
         'polymorphic_identity': 'work'
@@ -174,3 +176,16 @@ class Book(Work):
 
     def get_identities():
         return 'dbpedia-owl:Book'
+
+
+class ClicheWikipediaEdge(Base):
+    """Correspondence between Works of Cliche and Wikipedia"""
+
+    cliche_id = Column(Integer, ForeignKey('works.id'), primary_key=True)
+    cliche_work = relationship(ClicheWork)
+    wikipedia_name = Column(String, ForeignKey(Work.name), primary_key=True)
+    wikipedia_work = relationship(Work)
+    confidence = Column(Integer, default=0.5)
+
+    __tablename__ = 'cliche_wikipedia_edge'
+    __repr_columns__ = cliche_id, wikipedia_name, confidence

--- a/cliche/work.py
+++ b/cliche/work.py
@@ -5,19 +5,16 @@
 import enum
 
 from sqlalchemy.orm import foreign, relationship, remote
-from sqlalchemy.schema import Column, ForeignKey, ForeignKeyConstraint
+from sqlalchemy.schema import Column, ForeignKey
 from sqlalchemy.sql.functions import now
 from sqlalchemy.types import Date, DateTime, Integer, String
 
 from .orm import Base
 from .sqltypes import EnumType, prevent_discriminator_from_changing
 from .name import Nameable
-from .services.wikipedia.work import Work as WikiWork
-from .services.tvtropes.entities import Entity as TvEntity
 
-__all__ = ('Character', 'CliTvCorres', 'CliWikiCorres', 'Credit', 'Franchise',
-           'Genre', 'Role', 'Work', 'WorkCharacter', 'WorkFranchise',
-           'WorkGenre', 'World')
+__all__ = ('Character', 'Credit', 'Franchise', 'Genre', 'Role', 'Work',
+           'WorkCharacter', 'WorkFranchise', 'WorkGenre', 'World')
 
 
 class Role(enum.Enum):
@@ -65,40 +62,6 @@ class Character(Nameable):
     __mapper_args__ = {
         'polymorphic_identity': 'characters',
     }
-
-
-class CliTvCorres(Base):
-    """Correspondence between Works of Cliche and TV Tropes"""
-
-    cli_id = Column(Integer, ForeignKey('works.id'), primary_key=True)
-    cli_work = relationship(lambda: Work)
-    tv_namespace = Column(String, primary_key=True)
-    tv_name = Column(String, primary_key=True)
-    tv_entity = relationship(TvEntity,
-                             foreign_keys=[tv_namespace, tv_name])
-    confidence = Column(Integer, default=0.5)
-
-    __tablename__ = 'cli_tv_corres'
-    __table_args__ = (
-        ForeignKeyConstraint(
-            [tv_namespace, tv_name],
-            [TvEntity.namespace, TvEntity.name]
-        ),
-    )
-    __repr_columns__ = cli_id, tv_namespace, tv_name, confidence
-
-
-class CliWikiCorres(Base):
-    """Correspondence between Works of Cliche and Wikipedia"""
-
-    cli_id = Column(Integer, ForeignKey('works.id'), primary_key=True)
-    cli_work = relationship(lambda: Work)
-    wiki_name = Column(String, ForeignKey(WikiWork.name), primary_key=True)
-    wiki_work = relationship(WikiWork)
-    confidence = Column(Integer, default=0.5)
-
-    __tablename__ = 'cli_wiki_corres'
-    __repr_columns__ = cli_id, wiki_name, confidence
 
 
 class Credit(Base):
@@ -241,7 +204,7 @@ class Work(Nameable):
     #: (:class:`str`) Work media type.
     media_type = Column(String, nullable=False)
 
-    #: (:class:`datetimeself.date`) The publication date.
+    #: (:class:`datetime.date`) The publication date.
     published_at = Column(Date)
 
     #: (:class:`collections.abc.MutableSet`) The set of
@@ -288,10 +251,6 @@ class Work(Nameable):
     #: :class:`Trope`.
     tropes = relationship(Trope, secondary='work_tropes',
                           collection_class=set)
-
-    tv_corres = relationship(CliTvCorres, collection_class=set)
-
-    wiki_corres = relationship(CliWikiCorres, collection_class=set)
 
     #: (:class:`datetime.datetime`) The date and time on which
     #: the record was created.

--- a/tests/wikipedia_work_test.py
+++ b/tests/wikipedia_work_test.py
@@ -1,4 +1,6 @@
-from cliche.services.wikipedia.work import Entity, Artist, Work, Film, Book
+from cliche.services.wikipedia.work import (
+    ClicheWikipediaEdge, Entity, Artist, Work, Film, Book
+)
 
 
 def test_properties():
@@ -61,3 +63,11 @@ def test_book_properties():
         'dbpedia-owl:numberOfPages',
     }
     assert Book.PROPERTIES == book_properties
+
+
+def test_wikipedia_edge(fx_edges):
+    fx_edges.wikipedia_film.corres == {
+        ClicheWikipediaEdge(cliche_work=fx_edges.cliche_work,
+                            wikipedia_work=fx_edges.wikipedia_film,
+                            confidence=0.9),
+    }

--- a/tests/work_test.py
+++ b/tests/work_test.py
@@ -1,5 +1,4 @@
-from cliche.work import (CliTvCorres, CliWikiCorres, Credit, Franchise, Role,
-                         Work, World)
+from cliche.work import Credit, Franchise, Role, Work, World
 
 
 def test_genres_of_work(fx_works, fx_genres):
@@ -160,29 +159,6 @@ def test_tropes_be_subordinate_to_works(fx_tropes):
 
     assert fx_tropes.ass_kicking_pose.works == {fx_tropes.dragon_ball_z}
     assert fx_tropes.cute_is_evil.works == {fx_tropes.dragon_ball_z}
-
-
-def test_correspondences(fx_corres):
-    fx_corres.cli_work.tv_corres == {
-        CliTvCorres(cli_work=fx_corres.cli_work,
-                    tv_entity=fx_corres.tv_entity,
-                    confidence=0.8),
-    }
-    fx_corres.cli_work.wiki_corres == {
-        CliWikiCorres(cli_work=fx_corres.cli_work,
-                      wiki_work=fx_corres.wiki_film,
-                      confidence=0.9),
-    }
-    fx_corres.wiki_film.corres == {
-        CliWikiCorres(cli_work=fx_corres.cli_work,
-                      wiki_work=fx_corres.wiki_film,
-                      confidence=0.9),
-    }
-    fx_corres.tv_entity.corres == {
-        CliTvCorres(cli_work=fx_corres.cli_work,
-                    tv_entity=fx_corres.tv_entity,
-                    confidence=0.8),
-    }
 
 
 def test_discriminator():


### PR DESCRIPTION
- `CliTvCorres` is ORM class for the table for correspondence of a pair of Cliche work and TV Tropes entity
- `CliWikiCorres` is ORM class for the table for correspondence of a pair of Cliche work and Wikipedia work
